### PR TITLE
Add ability to dump core after each optimization pass

### DIFF
--- a/fusion-plugin.cabal
+++ b/fusion-plugin.cabal
@@ -35,9 +35,13 @@ source-repository head
 
 library
   exposed-modules:     Fusion.Plugin
-  build-depends:       base >= 4.0    && <  5.0
-                     , syb  >= 0.7    && <  0.8
-                     , ghc  >= 7.10.3 && <= 8.8.2
+  build-depends:       base       >= 4.0     && <  5.0
+                     , containers >= 0.5.6.2 && <  0.7
+                     , directory  >= 1.2.2.0 && <  1.4
+                     , filepath   >= 1.4     && <  1.5
+                     , ghc        >= 7.10.3  && <= 8.8.2
+                     , syb        >= 0.7     && <  0.8
+                     , time       >= 1.5     && <  1.10
 
                      , fusion-plugin-types >= 0.1 && < 0.2
   hs-source-dirs:      src

--- a/fusion-plugin.cabal
+++ b/fusion-plugin.cabal
@@ -35,13 +35,14 @@ source-repository head
 
 library
   exposed-modules:     Fusion.Plugin
-  build-depends:       base       >= 4.0     && <  5.0
-                     , containers >= 0.5.6.2 && <  0.7
-                     , directory  >= 1.2.2.0 && <  1.4
-                     , filepath   >= 1.4     && <  1.5
-                     , ghc        >= 7.10.3  && <= 8.8.2
-                     , syb        >= 0.7     && <  0.8
-                     , time       >= 1.5     && <  1.10
+  build-depends:       base         >= 4.0     && <  5.0
+                     , containers   >= 0.5.6.2 && <  0.7
+                     , directory    >= 1.2.2.0 && <  1.4
+                     , filepath     >= 1.4     && <  1.5
+                     , ghc          >= 7.10.3  && <= 8.8.2
+                     , syb          >= 0.7     && <  0.8
+                     , time         >= 1.5     && <  1.10
+                     , transformers >= 0.4     && < 0.6
 
                      , fusion-plugin-types >= 0.1 && < 0.2
   hs-source-dirs:      src

--- a/src/Fusion/Plugin.hs
+++ b/src/Fusion/Plugin.hs
@@ -50,12 +50,22 @@ module Fusion.Plugin
 where
 
 -- Explicit/qualified imports
-import Control.Monad (when)
+import Control.Monad (when, unless)
+import Data.Char (isSpace)
 import Data.Generics.Schemes (everywhere)
 import Data.Generics.Aliases (mkT)
+import Data.IORef (readIORef, writeIORef)
+import Data.Time (getCurrentTime)
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath ((</>), takeDirectory)
+import System.IO (Handle, IOMode(..), withFile, hSetEncoding, utf8)
+
+import ErrUtils (mkDumpDoc, Severity(..))
 import Outputable (Outputable(..), text)
+import PprCore (pprCoreBindingsWithSize, pprRules)
 
 import qualified Data.List as DL
+import qualified Data.Set as Set
 
 -- Implicit imports
 import GhcPlugins
@@ -372,10 +382,159 @@ reportAnns reportMode guts = do
     transformBind _ _ bndr = return bndr
 
 -------------------------------------------------------------------------------
+-- Dump core passes
+-------------------------------------------------------------------------------
+
+chooseDumpFile :: DynFlags -> FilePath -> Maybe FilePath
+chooseDumpFile dflags suffix
+        | Just prefix <- getPrefix
+
+        = Just $ setDir (prefix ++ suffix)
+
+        | otherwise
+
+        = Nothing
+
+        where getPrefix
+                 -- dump file location is being forced
+                 --      by the --ddump-file-prefix flag.
+               | Just prefix <- dumpPrefixForce dflags
+                  = Just prefix
+                 -- dump file location chosen by DriverPipeline.runPipeline
+               | Just prefix <- dumpPrefix dflags
+                  = Just prefix
+                 -- we haven't got a place to put a dump file.
+               | otherwise
+                  = Nothing
+              setDir f = case dumpDir dflags of
+                         Just d  -> d </> f
+                         Nothing ->       f
+
+withDumpFileHandle :: DynFlags -> FilePath -> (Maybe Handle -> IO ()) -> IO ()
+withDumpFileHandle dflags suffix action = do
+    let mFile = chooseDumpFile dflags suffix
+    case mFile of
+      Just fileName -> do
+        let gdref = generatedDumps dflags
+        gd <- readIORef gdref
+        let append = Set.member fileName gd
+            mode = if append then AppendMode else WriteMode
+        unless append $
+            writeIORef gdref (Set.insert fileName gd)
+        createDirectoryIfMissing True (takeDirectory fileName)
+        withFile fileName mode $ \handle -> do
+            -- We do not want the dump file to be affected by
+            -- environment variables, but instead to always use
+            -- UTF8. See:
+            -- https://gitlab.haskell.org/ghc/ghc/issues/10762
+            hSetEncoding handle utf8
+            action (Just handle)
+      Nothing -> action Nothing
+
+dumpSDocWithStyle :: PprStyle -> DynFlags -> FilePath -> String -> SDoc -> IO ()
+dumpSDocWithStyle sty dflags suffix hdr doc =
+    withDumpFileHandle dflags suffix writeDump
+  where
+    -- write dump to file
+    writeDump (Just handle) = do
+        doc' <- if null hdr
+                then return doc
+                else do t <- getCurrentTime
+                        let timeStamp = if (gopt Opt_SuppressTimestamps dflags)
+                                          then empty
+                                          else text (show t)
+                        let d = timeStamp
+                                $$ blankLine
+                                $$ doc
+                        return $ mkDumpDoc hdr d
+        defaultLogActionHPrintDoc dflags handle doc' sty
+
+    -- write the dump to stdout
+    writeDump Nothing = do
+        let (doc', severity)
+              | null hdr  = (doc, SevOutput)
+              | otherwise = (mkDumpDoc hdr doc, SevDump)
+        putLogMsg dflags NoReason severity noSrcSpan sty doc'
+
+dumpSDoc :: DynFlags -> PrintUnqualified -> FilePath -> String -> SDoc -> IO ()
+dumpSDoc dflags print_unqual
+    = dumpSDocWithStyle dump_style dflags
+  where dump_style = mkDumpStyle dflags print_unqual
+
+dumpPassResult :: DynFlags
+               -> PrintUnqualified
+               -> FilePath
+               -> SDoc                  -- Header
+               -> SDoc                  -- Extra info to appear after header
+               -> CoreProgram -> [CoreRule]
+               -> IO ()
+dumpPassResult dflags unqual suffix hdr extra_info binds rules = do
+   dumpSDoc dflags unqual suffix (showSDoc dflags hdr) dump_doc
+
+  where
+
+    dump_doc  = vcat [ nest 2 extra_info
+                     , blankLine
+                     , pprCoreBindingsWithSize binds
+                     , ppUnless (null rules) pp_rules ]
+    pp_rules = vcat [ blankLine
+                    , text "------ Local rules for imported ids --------"
+                    , pprRules rules ]
+
+dumpResult
+    :: DynFlags
+    -> PrintUnqualified
+    -> Int
+    -> SDoc
+    -> CoreProgram
+    -> [CoreRule]
+    -> IO ()
+dumpResult dflags print_unqual counter todo binds rules =
+    dumpPassResult dflags print_unqual suffix hdr (text "") binds rules
+
+    where
+
+    hdr = text "["
+        GhcPlugins.<> int counter
+        GhcPlugins.<> text "] "
+        GhcPlugins.<> todo
+
+    suffix = show counter ++ "-"
+        ++ map (\x -> if isSpace x then '-' else x)
+               (showSDoc dflags todo)
+
+dumpCore :: Int -> SDoc -> ModGuts -> CoreM ModGuts
+dumpCore counter todo
+    guts@(ModGuts
+        { mg_rdr_env = rdr_env
+        , mg_binds = binds
+        , mg_rules = rules
+        }) = do
+    dflags <- getDynFlags
+    putMsgS $ "fusion-plugin: dumping core "
+        ++ show counter ++ " " ++ showSDoc dflags todo
+
+    let print_unqual = mkPrintUnqualified dflags rdr_env
+    liftIO $ dumpResult dflags print_unqual counter todo binds rules
+    return guts
+
+dumpCorePass :: Int -> SDoc -> CoreToDo
+dumpCorePass counter todo =
+    CoreDoPluginPass "Fusion plugin dump core" (dumpCore counter todo)
+
+_insertDumpCore :: [CoreToDo] -> [CoreToDo]
+_insertDumpCore todos = dumpCorePass 0 (text "Initial ") : go 1 todos
+  where
+    go _ [] = []
+    go counter (todo:rest) =
+        todo : dumpCorePass counter (text "After " GhcPlugins.<> ppr todo)
+             : go (counter + 1) rest
+
+-------------------------------------------------------------------------------
 -- Install our plugin core pass
 -------------------------------------------------------------------------------
 
--- Inserts the given list of 'CoreToDo' after the simplifier phase @n@.
+-- Inserts the given list of 'CoreToDo' after the simplifier phase 0.
 insertAfterSimplPhase0
     :: [CoreToDo] -> [CoreToDo] -> CoreToDo -> [CoreToDo]
 insertAfterSimplPhase0 origTodos ourTodos report =
@@ -418,6 +577,10 @@ install _ todos = do
     --
     -- TODO do not run simplify if we did not do anything in markInline phase.
     return $
+-- XXX this can be controlled via command line options
+#ifdef DUMP_CORE
+        _insertDumpCore $
+#endif
         insertAfterSimplPhase0
             todos
             [ doMarkInline ReportSilent False True

--- a/src/Fusion/Plugin.hs
+++ b/src/Fusion/Plugin.hs
@@ -531,6 +531,13 @@ dumpPassResult dflags unqual suffix hdr extra_info binds rules = do
                     , text "------ Local rules for imported ids --------"
                     , pprRules rules ]
 
+filterOutLast :: (a -> Bool) -> [a] -> [a]
+filterOutLast _ [] = []
+filterOutLast p [x]
+    | p x = []
+    | otherwise = [x]
+filterOutLast p (x:xs) = x : filterOutLast p xs
+
 dumpResult
     :: DynFlags
     -> PrintUnqualified
@@ -550,8 +557,10 @@ dumpResult dflags print_unqual counter todo binds rules =
         GhcPlugins.<> todo
 
     suffix = show counter ++ "-"
-        ++ map (\x -> if isSpace x then '-' else x)
-               (showSDoc dflags todo)
+        ++ (map (\x -> if isSpace x then '-' else x)
+               $ filterOutLast isSpace
+               $ takeWhile (/= '(')
+               $ showSDoc dflags todo)
 
 dumpCore :: Int -> SDoc -> ModGuts -> CoreM ModGuts
 dumpCore counter todo


### PR DESCRIPTION
Cores are dumped in different files numbered in an increasing order based on
the index of the optimization pass starting from 0. Outputs from one pass to
the next can be compared to see what happend in a given pass.