### PR TITLE
Enable inline on construction cases

### DIFF
--- a/src/Fusion/Plugin.hs
+++ b/src/Fusion/Plugin.hs
@@ -842,6 +842,8 @@ install args todos = do
             , fusionSimplify dflags
             , fusionMarkInline ReportSilent False True
             , fusionSimplify dflags
+            , fusionMarkInline ReportSilent False True
+            , fusionSimplify dflags
             -- This lets us know what was left unfused after all the inlining
             -- and case-of-case transformations.
             , let msg = "Check unfused (post inlining)"

--- a/src/Fusion/Plugin.hs
+++ b/src/Fusion/Plugin.hs
@@ -551,7 +551,7 @@ markInline reportMode failIt transform guts = do
                     uniqConstr constrs showDetailsConstr
 
         let bind' = do
-                let allBinders = uniqPat -- ++ uniqConstr
+                let allBinders = uniqPat ++ uniqConstr
                 if transform && (not $ null allBinders)
                 then setInlineOnBndrs allBinders bind
                 else bind

--- a/src/Fusion/Plugin.hs
+++ b/src/Fusion/Plugin.hs
@@ -859,7 +859,10 @@ install _ todos = do
 #endif
 
 plugin :: Plugin
-plugin = defaultPlugin {installCoreToDos = install}
+plugin = defaultPlugin
+    { installCoreToDos = install
+    , pluginRecompile = purePlugin
+    }
 
 -- Orphan instance for 'Fuse'
 instance Outputable Fuse where


### PR DESCRIPTION
This is to fuse the Partial/Done constructors for the following code, when using terminating folds composewell/streamly#770 

```
main :: IO ()
main = do
    inh <- openFile "benchmark-tmpin-100MB.txt" ReadMode
    outh <- openFile "/dev/null" WriteMode

    S.fold (FH.write outh)
        $ AS.interposeSuffix 10
        $ AS.splitOnSuffix 10
        $ FH.toChunks inh
```