### PR TITLE
Add option to control verbosity level with command line args.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Build files/directories
+/.stack-work/
+/dist/
+/dist-newstyle/
+
+# Local GHC and Cabal related files
+.ghc.environment*
+cabal.project.local
+
+# Temp files created by Vim/Neovim
+*.swp
+*.swo
+*~
+
+# Other
+.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Enhancements
+
+- Plugin now forces inline on binders that return a type annotated with Fuse.
+- `Fusion.Plugin` now accepts new command line arguments to control the
+  verbosity of the plugin's reporting phase. Refer to `README.md` for usage.
+
 ## 0.2.1
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -47,12 +47,17 @@ This plugin was primarily motivated by
 general.
 
 To use this plugin, add this package to your `build-depends`
-and pass the following to your ghc-options: `ghc-options: -O2
--fplugin=Fusion.Plugin`
+and pass the following to your ghc-options:
+`ghc-options: -O2 -fplugin=Fusion.Plugin`
 
-To dump core after each core to core transformation, pass the argument
-`-fplugin-opt=Fusion.Plugin:dump-core`. Output from each
-transformation is then printed in a different file.
+### Plugin options
+
+`-fplugin-opt=Fusion.Plugin:dump-core`: dump core after each
+core-to-core transformation. Output from each transformation is printed
+in a different file.
+
+`-fplugin-opt=verbose=1`: report unfused functions. Verbosity levels `2`, `3`,
+`4` can be used for more verbose output.
 
 ## See also
 


### PR DESCRIPTION
- Adds `-v0`, `-v1`, `-v2`, `-verbose=warn` to control verbosity level
- Changes `dump-core` to `-ddump-core`